### PR TITLE
support using colon for value assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,11 @@ The runes (characters) that will be recognised as enclosing quotes are defined i
 	
 	EnclosingQuoteSymbols
 and default to the single (') and double (") quote symbols.
+
+### Assignment with Colon
+
+Some INI files use the colon for assignment rather than the equals sign. To 
+support this set:
+
+    UseColonAssignment = true
+in your IniOptions.

--- a/inifile.go
+++ b/inifile.go
@@ -255,6 +255,7 @@ const GLOBAL_SECTION = ""
 //		CommentEscapePrefix				"\"
 //		StripEnclosingQuotes			false
 //		EnclosingQuoteSymbols			[]rune{'\'','"'}
+//      UseColonAssignment              false
 //
 func DefaultIniOptions() *IniOptions {
 	io := new(IniOptions)
@@ -272,6 +273,7 @@ func DefaultIniOptions() *IniOptions {
 	io.CommentEscapePrefix = "\\"
 	io.StripEnclosingQuotes = false
 	io.EnclosingQuoteSymbols = []rune{'\'','"'}
+    io.UseColonAssignment = false
 
 	return io
 }
@@ -328,6 +330,8 @@ type IniOptions struct {
 	//The symbols that are used as enclosing quotes
 	EnclosingQuoteSymbols []rune
 
+    //Assignment uses colon not equals
+    UseColonAssignment bool
 }
 
 // NewIniConfigFromPath loads the INI file at the supplied path into a new IniConfig object.
@@ -393,6 +397,7 @@ func NewIniConfigFromFileWithOptions(file *os.File, options *IniOptions) (*IniCo
 
 const rx_section = "\\[(.*)\\]"
 const rx_property = "([^=]*)=(.*)"
+const rx_colon_property = "([^=]*):(.*)"
 
 // IniConfig provides access to configuration loaded in from an INI file. Functions exist to
 // check whether a section or property exists; to recover the raw string value of a property or
@@ -678,10 +683,15 @@ func (ic *IniConfig) parse(cf *os.File) error {
 	s := bufio.NewScanner(cf)
 	section := GLOBAL_SECTION
 
-	sectionRx := regexp.MustCompile(rx_section)
-	propRx := regexp.MustCompile(rx_property)
-
 	options := ic.options
+
+    var propRx *regexp.Regexp
+	sectionRx := regexp.MustCompile(rx_section)
+    if options.UseColonAssignment == true {
+	    propRx = regexp.MustCompile(rx_colon_property)
+    } else {
+	    propRx = regexp.MustCompile(rx_property)
+    }
 
 	lineNumber := 0
 

--- a/inifile_test.go
+++ b/inifile_test.go
@@ -1,17 +1,17 @@
 package inifile
 
 import (
-	"path/filepath"
-	"testing"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"testing"
 )
 
 const testfiles_base = "testfiles"
 const simple_file = "simple.ini"
 const types_file = "types.ini"
-
+const colon_file = "colons.ini"
 
 func simplePath() string {
 	return filepath.Join(testfiles_base, simple_file)
@@ -19,6 +19,10 @@ func simplePath() string {
 
 func typesPath() string {
 	return filepath.Join(testfiles_base, types_file)
+}
+
+func colonPath() string {
+	return filepath.Join(testfiles_base, colon_file)
 }
 
 func TestNewFunctions(t *testing.T) {
@@ -571,6 +575,23 @@ func TestBooleanHandling(t *testing.T) {
 
 }
 
+func TestColonParse(t *testing.T) {
+	path := colonPath()
+	options := DefaultIniOptions()
+	options.UseColonAssignment = true
+
+	ic, err := NewIniConfigFromPathWithOptions(path, options)
+	if err != nil {
+		t.Errorf("Unexpected Error: %s", err)
+	}
+	val, err := ic.Value("Section1", "name1")
+	if err != nil {
+		t.Errorf("Can't find expected string '%s': error: %s", "value1", err)
+	}
+	if val != "value1" {
+		t.Errorf("Got %s, expected %s", val, "value1")
+	}
+}
 
 func expectBool(t *testing.T, ic *IniConfig, sectionName, propertyName string, expected bool) {
 

--- a/testfiles/colons.ini
+++ b/testfiles/colons.ini
@@ -1,0 +1,3 @@
+[Section1]
+
+name1:value1


### PR DESCRIPTION
I'm dealing with an ini file that I don't control the format of, it uses colons to assign values.  Your package is great and easily modified to support colons via a new Option.  I hope you will accept this PR.